### PR TITLE
workflows: Remove cisco-ospo dependencies

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   run-scorecard:
     # Call reusable workflow file
-    uses: cisco-ospo/.github/.github/workflows/_scorecard.yml@main
+    uses: bloomberg/.github/.github/workflows/_scorecard.yml@main
     permissions:
       id-token: write
       security-events: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   mark-stale:
     # Call reusable workflow file
-    uses: cisco-ospo/.github/.github/workflows/_stale.yml@main
+    uses: bloomberg/.github/.github/workflows/_stale.yml@main
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
## Description

This repo was created from the Cisco OSPO template: https://github.com/cisco-ospo/oss-template
This PR replaces the Cisco OSPO GitHub Action dependencies that were appearing in [this repo's SBOM](https://github.com/user-attachments/files/19041462/bloomberg_oss-template_61c7f8.json) with references to our reusable workflows:

- https://github.com/bloomberg/.github/blob/9663023787d4f7e7760f7b961951e7eb17428ecc/.github/workflows/_scorecard.yml
- https://github.com/bloomberg/.github/blob/9663023787d4f7e7760f7b961951e7eb17428ecc/.github/workflows/_stale.yml