### PR TITLE
Add OpenSSF Baseline compliance docs (partial coverage)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Secrets and credentials
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+credentials.json
+.secret*
+*.secrets
+
+# Cloud provider credentials
+.aws/credentials
+.gcp/credentials.json
+.azure/credentials

--- a/.project/darnit.yaml
+++ b/.project/darnit.yaml
@@ -1,13 +1,13 @@
 # .project/darnit.yaml - Darnit Extension
-# 
+#
 # Extension fields for security tooling (OpenSSF Baseline, etc.)
 # Standard CNCF .project fields are in project.yaml
 
-slug: ''
-project_lead: ''
-cncf_slack_channel: ''
+slug: ""
+project_lead: ""
+cncf_slack_channel: ""
 package_managers: {}
-version: '1.0'
+version: "1.0"
 controls: {}
 context:
   has_subprojects: false
@@ -17,6 +17,6 @@ context:
   ci_provider: github
   platform: github
   maintainers:
-  - '@bloomberg/ospo-admins'
+    - "@bloomberg/ospo-admins"
   security_contact: oss_security@bloomberg.net
   governance_model: corporate

--- a/.project/darnit.yaml
+++ b/.project/darnit.yaml
@@ -1,0 +1,22 @@
+# .project/darnit.yaml - Darnit Extension
+# 
+# Extension fields for security tooling (OpenSSF Baseline, etc.)
+# Standard CNCF .project fields are in project.yaml
+
+slug: ''
+project_lead: ''
+cncf_slack_channel: ''
+package_managers: {}
+version: '1.0'
+controls: {}
+context:
+  has_subprojects: false
+  has_releases: true
+  is_library: false
+  has_compiled_assets: false
+  ci_provider: github
+  platform: github
+  maintainers:
+  - '@bloomberg/ospo-admins'
+  security_contact: oss_security@bloomberg.net
+  governance_model: corporate

--- a/.project/project.yaml
+++ b/.project/project.yaml
@@ -1,12 +1,12 @@
 # .project/project.yaml - CNCF Project Configuration
 # https://github.com/cncf/automation/tree/main/utilities/dot-project
-# 
+#
 # This file contains standard CNCF .project fields.
 # Extension fields are in separate files (darnit.yaml, etc.)
 
 name: oss-template
-description: ''
-schema_version: '1.0'
+description: ""
+schema_version: "1.0"
 type: software
 maturity_log: []
 repositories: []

--- a/.project/project.yaml
+++ b/.project/project.yaml
@@ -1,0 +1,20 @@
+# .project/project.yaml - CNCF Project Configuration
+# https://github.com/cncf/automation/tree/main/utilities/dot-project
+# 
+# This file contains standard CNCF .project fields.
+# Extension fields are in separate files (darnit.yaml, etc.)
+
+name: oss-template
+description: ''
+schema_version: '1.0'
+type: software
+maturity_log: []
+repositories: []
+social: {}
+mailing_lists: []
+security:
+  contact: oss_security@bloomberg.net
+documentation:
+  support:
+    path: SUPPORT.md
+audits: []

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,49 @@
+# Support
+
+## Getting Help
+
+Thanks for using oss-template! Here are some ways to get help:
+
+### Documentation
+
+- [Readme](README.md) — project overview and quickstart
+- [docs/](docs/) — architecture, guides, and policy documents
+- [CONTRIBUTING](CONTRIBUTING.md) — how to contribute
+
+### Issues
+
+If you've found a bug or have a feature request:
+
+1. Search [existing issues](https://github.com/bloomberg/oss-template/issues) first
+2. If not found, [open a new issue](https://github.com/bloomberg/oss-template/issues/new)
+
+### Security Issues
+
+**Please do not report security vulnerabilities through public issues.**
+
+See our [Security Policy](SECURITY.md) for responsible disclosure instructions.
+
+## Response Times
+
+This is an open source project. Response times may vary based on
+maintainer availability. We appreciate your patience!
+
+## Contributing
+
+Want to help improve oss-template? See our [Contributing Guide](CONTRIBUTING.md).
+
+## Support Scope
+
+| Version | Status | Support Duration |
+| ------- | ------ | ---------------- |
+| latest  | Active | Current release  |
+
+Support includes bugfixes and security patches for supported versions.
+
+## End of Support
+
+When a version reaches end of life (EOL):
+
+- A deprecation notice will be added to release notes
+- A minimum of 30 days notice will be given before support ends
+- Users are encouraged to upgrade to a supported version


### PR DESCRIPTION
# Description

Ran a [darnit](https://github.com/kusari-oss/darnit) OpenSSF Baseline audit (OSPS v2025.10.10) against this repo and addressed the auto-remediable gaps that don't require org-level policy sign-off:

- `SUPPORT.md` — support scope, response times, and end-of-support policy (resolves `OSPS-DO-03.01`, `OSPS-DO-04.01`, `OSPS-DO-05.01`)
- `.gitignore` — secret/credential file patterns (resolves `OSPS-BR-07.01`)
- `.project/project.yaml`, `.project/darnit.yaml` — CNCF-style project metadata (maintainers: `@bloomberg/ospo-admins`, governance: corporate, security contact aligned with what's already documented in `SECURITY.md`)

**Deliberately excluded from this PR:** `docs/DEPENDENCIES.md`, `docs/SECURITY-ASSESSMENT.md`, `docs/SCA-POLICY.md`, `docs/SAST-POLICY.md`, `docs/VEX-POLICY.md`, `docs/SECRETS-POLICY.md`, `docs/TESTING.md`, `docs/RELEASE-VERIFICATION.md`, and a generated `docs/THREAT_MODEL.md`. These are security/process policy docs that would get copied verbatim into every downstream repo templated from this one, and need real review before being adopted as org-wide defaults rather than being auto-generated.

Audit went from 40/62 to 42/62 passing controls. Remaining failures need either a real dependency manifest (not applicable to a codeless template) or the policy docs above once reviewed.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/bloomberg/oss-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable) — none found; searched open/closed issues, no overlap
- [x] I have verified this change is not present in other open pull requests — checked #36/#37 (Dependabot bumps only, unrelated)
- [x] Functionality is documented
- [x] All code style checks pass — `super-linter` and `dependency-review` both green
- [ ] New code contribution is covered by automated tests — N/A, this is a docs/config-only change to a template repo with no application code
- [ ] All new and existing tests pass — N/A, no test suite exists in this repo (see `.github/workflows/`: lint, dependency-review, codeql, scorecard, stale — no test runner)
